### PR TITLE
list.php returns now a valid RSD

### DIFF
--- a/list.php
+++ b/list.php
@@ -13,55 +13,82 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
- 
+
 /**
  * @package   local_rsd
  * @copyright 2016, Goran Josic <goran.josic@usi.ch>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once('../../config.php');
+// Don't assume a specific installation location but find the moodle root
+$cwd = dirname(__FILE__);
 
-global $CFG;
+while ($cwd != "/")
+{
+    // detect the moodle root
+    if (file_exists($cwd . DIRECTORY_SEPARATOR . 'config.php') &&
+        file_exists($cwd . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'moodlelib.php'))
+    {
+        break;
+    }
+    $cwd = dirname($cwd);
+}
+
+chdir($cwd);
+// will fail if we are not within a moodle instance
+require_once('config.php');
+
+global $CFG, $SITE;
 
 //*******************************************************************
 // How does this work?
 // Scan all the directories in the moodle root and local folder.
-// If they contains rsd.php include it in the array.
+// If they contain a rsd.php then extract the APIS and map to the global array.
 // Convert the array in JSON and print it as output.
 //*******************************************************************
-function extract_apis($rsd_path) {
+function extract_apis($rsd_path, $homePageLink, $engineLink) {
+    // plugins may need to verify that the homePageLink and the engineLink
+    // are not empty in order to provide absolute links
+
+    global $CFG, $DB; // ensure all globals are present within the scope
+    $apis = array();  // instanciate a local api list for the plugin
+
+    // NOTE: the $apis is an associative array (key => value), don't use push or unshift
 	include($rsd_path);
-	// the description element has been initialized in the rsd.php file.
+
+	// return the api list
 	return $apis;
 }
 
-function dirscan($list) {
-	$apis = array();
-	foreach($list as $directory) {
-		$iterator = new \DirectoryIterator ( $directory );
-		foreach($iterator as $fileinfo) {
-			if($fileinfo->isDir() && !$fileinfo->isDot()) { // filter files and dot directories
-				$rsd_path = $fileinfo->getPathname().DIRECTORY_SEPARATOR.'rsd.php';
-				if(file_exists($rsd_path)) {
-					$apis = extract_apis($rsd_path);
-				}
-			}
-		}
-	}
-	return $apis;
-}
-
-$services_descriptions = array(
-			'engineName' => 'Moodle',
-			'engineLink' => 'webservice/',
-			'homePageLink' => $CFG->wwwroot . DIRECTORY_SEPARATOR
+$service_descriptions = array(
+			'engineName' => $SITE->fullname, // there will be more than 1 moodle instance
+			'engineLink' => '', // in moodle there is no single webservice folder
+			'homePageLink' => $CFG->wwwroot . DIRECTORY_SEPARATOR,
+            'apis'=> array()
 		);
 
+// load the web-service APIs for all plugins in the system
+foreach (array($CFG->dirroot,
+               $CFG->dirroot .DIRECTORY_SEPARATOR. 'local') as $dir) {
+    $iterator = new DirectoryIterator($dir);
+    foreach($iterator as $fileinfo) {
+        if($fileinfo->isDir() && !$fileinfo->isDot()) { // filter files and dot directories
+            $rsd_path = $fileinfo->getPathname().DIRECTORY_SEPARATOR.'rsd.php';
+            if(file_exists($rsd_path)) {
+                $localapis = extract_apis($rsd_path,
+                                          $service_descriptions['homePageLink'],
+                                          $service_descriptions['engineLink']);
 
-/* $services_descriptions['apis'] = dirscan(array('../..', '..')); */
-$services_descriptions['apis'] = dirscan(array('..'));
+                // map the plugin APIs into the global list
+                foreach ($localapis as $name => $api) {
+                    $service_descriptions['apis'][$name] = $api;
+                }
+            }
+        }
+    }
+}
+
 // encode in JSON and print out.
 header('Content-type: application/json');
-echo json_encode($services_descriptions);
+echo json_encode($service_descriptions);
 ?>

--- a/rsd.php
+++ b/rsd.php
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
- 
+
 /**
  * @package   local_rsd
  * @copyright 2016, Goran Josic <goran.josic@usi.ch>
@@ -30,8 +30,6 @@
 // then available for further usage.
 //*******************************************************************
 
-require_once('../../config.php');
-global $CFG, $DB;
 require_once($CFG->libdir . '/adminlib.php');
 require_once($CFG->libdir . '/externallib.php');
 require_once($CFG->dirroot . '/webservice/lib.php');
@@ -39,29 +37,33 @@ require_once($CFG->dirroot . '/admin/webservice/forms.php');
 
 // get all enabled web services
 $services = $DB->get_records('external_services', array('enabled' => 1));
+
 // get the list of the active transport protocols
 $transport_protocols = empty($CFG->webserviceprotocols) ?  array() : explode(',', $CFG->webserviceprotocols);
-
-// this array contains all the service description entries
-$apis = array();
 
 foreach($services as $service) {
 	foreach($transport_protocols as $protocol) {
 		$api_entry = array();
 		$webservicemanager = new webservice();
+
 		// get the webservice functions
 		$functions = $webservicemanager->get_external_functions($service->id);
 		foreach($functions as $function) {
 			$info = external_function_info($function);
-			$api_entry[$info->name] = array(
+
+            // create reverse domain notation to the moodle api names
+            // note that because the API Links are different for each protocol,
+            // the services need to have different names
+            $apiName = "org.moodle." . $protocol . "." . $info->name;
+
+            // append the service to the API list
+			$apis[$apiName] = array(
 				'notes' => $info->description,
 				'apiVersion' => $CFG->release,
-				'apiLink' => $protocol . DIRECTORY_SEPARATOR . 'server.php',
+				'apiLink' => 'webservice' . DIRECTORY_SEPARATOR . $protocol . DIRECTORY_SEPARATOR . 'server.php',
 				'transport' => array($protocol)
 			);
 		}
-		// append the entry
-		$apis[] = $api_entry;
 	}
 }
 ?>


### PR DESCRIPTION
I fixed list.php to return a valid RSD. 

Note that  I used the directory_separator also in links, which I adopted from your code for consistency. This might be a problem on windows installations, please verify that the directory separator is only used for includes from the file system. 

list.php
o  Now encapsulates only the extract_api call for the plugins, so they cannot manipulate service entries. Note, that for the mapping we may want to verify that a service name is not already claimed by a different plugin. I did not include this logic.
o the script now doesn't assume that the API is installed in a particular location within the moodle instance. 
o Don't use webservice/ as engineLink, because services can be installed also for other plugins.

+ extract_apis() provides all  globals and variables for the plugin scope, so ideally, plugins will just add their functions.
+ The engineName is now correctly the fullname of the moodle site.
+ Fixed some typos in the comments and variable names (avoid doubled plural)

rsd.php 
o only include calls that are essential for the api extraction and use scoped variables and globals.

+ have unique apiNames in reverse domain notation so we can distinguish different protocols and filter for specific moodle functions. 
